### PR TITLE
Added option uniqueDefaults: ensure unique ids when options.defaults = true

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,46 @@ Configuration (optional).
 
 #### options.defaults
 
-Whether to add default titles based on the title text (boolean, default: false).
+Whether to add default ids based on the title text (boolean, default: false).
+
+#### options.uniqueDefaults
+
+Whether to ensure that the default ids created by options.defaults are unique (boolean, default: true).
+Only relevant when options.defaults = true.
+Example:
+
+```markdown
+## heading
+### indroduction
+### argument
+## heading
+### introduction
+### argument
+```
+
+Will generate this output when options.defaults = true and options.uniqueDefaults = true:
+
+```html
+<h2 id="heading">heading</h2>
+<h3 id="indroduction">indroduction</h3>
+<h3 id="argument">argument</h3>
+<h2 id="heading-1">heading</h2>
+<h3 id="introduction-1">introduction</h3>
+<h3 id="argument-1">argument</h3>
+```
+
+Instead of this output, which is generated when options.defaults = true and options.uniqueDefaults = false:
+
+```html
+<h2 id="heading">heading</h2>
+<h3 id="indroduction">indroduction</h3>
+<h3 id="argument">argument</h3>
+<h2 id="heading">heading</h2>
+<h3 id="introduction">introduction</h3>
+<h3 id="argument">argument</h3>
+```
+
+The difference being that the last output contains duplicate ids in the generated html, which are avoided using options.uniqueDefaults = true.
 
 ##### Default Heading Input
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://prettier.io/)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat-square)](https://conventionalcommits.org)
 
-> The remark plugin for supporting [custom heading id](https://www.markdownguide.org/extended-syntax/#heading-ids) and Default Id
+> The remark plugin for supporting [custom heading id](https://www.markdownguide.org/extended-syntax/#heading-ids) and
+> Default Id
 
 ### Custom Heading Input
 
@@ -43,10 +44,15 @@ Example:
 
 ```markdown
 ## heading
-### indroduction
-### argument
-## heading
+
 ### introduction
+
+### argument
+
+## heading
+
+### introduction
+
 ### argument
 ```
 
@@ -72,7 +78,8 @@ Instead of this output, which is generated when options.defaults = true and opti
 <h3 id="argument">argument</h3>
 ```
 
-The difference being that the last output contains duplicate ids in the generated html, which are avoided using options.uniqueDefaults = true.
+The difference being that the last output contains duplicate ids in the generated html, which are avoided using
+options.uniqueDefaults = true.
 
 ##### Default Heading Input
 

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -71,6 +71,29 @@ describe('remarkHeadingId', function() {
 `)
   })
 
+  it('defaults with uniqueDefaults should generate distinct ids', function() {
+    let { contents } = remark()
+      .data('settings', {
+        position: false
+      })
+      .use(remarkHeadingId, { defaults: true, uniqueDefaults: true })
+      .use(stringify)
+      .use(html).processSync(` ## heading
+### introduction
+### argument
+## heading
+### introduction
+### argument`)
+    expect(contents).toMatchInlineSnapshot(`
+"<h2 id=\\"heading\\">heading</h2>
+<h3 id=\\"introduction\\">introduction</h3>
+<h3 id=\\"argument\\">argument</h3>
+<h2 id=\\"heading-1\\">heading</h2>
+<h3 id=\\"introduction-1\\">introduction</h3>
+<h3 id=\\"argument-1\\">argument</h3>"
+`)
+  })
+
   it('should parse well which contains inline syntax', function() {
     let { contents } = remark()
       .data('settings', {

--- a/index.js
+++ b/index.js
@@ -6,8 +6,11 @@
 const visit = require('unist-util-visit')
 const { setNodeId, getDefaultId } = require('./util')
 
-module.exports = function(options = { defaults: false }) {
+module.exports = function(options = { defaults: false, uniqueDefaults: true }) {
   return function(node) {
+
+    const uniqueDefaultIdsCounters = {}
+
     visit(node, 'heading', node => {
       let lastChild = node.children[node.children.length - 1]
       if (lastChild && lastChild.type === 'text') {
@@ -28,7 +31,18 @@ module.exports = function(options = { defaults: false }) {
 
       if (options.defaults) {
         // If no custom id was found, use default instead
-        setNodeId(node, getDefaultId(node.children))
+        let defaultIdCandidate = getDefaultId(node.children);
+        if (options.uniqueDefaults) {
+          if (uniqueDefaultIdsCounters?.[defaultIdCandidate] === undefined) {
+            // First time this default id is used: initialize counter
+            uniqueDefaultIdsCounters[defaultIdCandidate] = 0;
+          } else {
+            // Id already used: increment counter and append it to defaultIdCandidate
+            uniqueDefaultIdsCounters[defaultIdCandidate]++;
+            defaultIdCandidate += "-" + uniqueDefaultIdsCounters[defaultIdCandidate];
+          }
+        }
+        setNodeId(node, defaultIdCandidate);
       }
     })
   }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function(options = { defaults: false, uniqueDefaults: true }) {
         // If no custom id was found, use default instead
         let defaultIdCandidate = getDefaultId(node.children);
         if (options.uniqueDefaults) {
-          if (uniqueDefaultIdsCounters?.[defaultIdCandidate] === undefined) {
+          if (uniqueDefaultIdsCounters[defaultIdCandidate] === undefined) {
             // First time this default id is used: initialize counter
             uniqueDefaultIdsCounters[defaultIdCandidate] = 0;
           } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remark-heading-id",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remark-heading-id",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",


### PR DESCRIPTION
This change appends a counter variable to ids generated by options.defaults when the heading element's text is duplicated. The use case is detailed in README.md, which admitedly seems a bit too verbose to me.

Thanks for your code!