### PR TITLE
remove lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3126,6 +3126,11 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://bnpm.byted.org/escalade/-/escalade-3.1.1.tgz",
@@ -6017,7 +6022,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://bnpm.byted.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "remark-rehype": "^4.0.0"
   },
   "dependencies": {
-    "unist-util-visit": "^1.4.0",
-    "lodash": "^4.17.21"
+    "es-toolkit": "^1.46.1",
+    "unist-util-visit": "^1.4.0"
   }
 }

--- a/util.js
+++ b/util.js
@@ -1,4 +1,4 @@
-const _ = require('lodash')
+const { kebabCase } = require('es-toolkit/string')
 
 const isNonEmptyString = value => {
   if (value == null) {
@@ -29,7 +29,7 @@ const getDefaultId = children => {
 }
 
 const formatDefaultId = value => {
-  return _.kebabCase(value.replace(/\\s+/g, ' ').trim())
+  return kebabCase(value.replace(/\\s+/g, ' ').trim())
 }
 
 const setNodeId = (node, id) => {

--- a/util.js
+++ b/util.js
@@ -1,9 +1,19 @@
 const _ = require('lodash')
 
+const isNonEmptyString = value => {
+  if (value == null) {
+    return false
+  }
+  if (typeof value === 'string') {
+    return value.length > 0
+  }
+  return false
+}
+
 const extractText = children => {
   return children
     .map(child => {
-      if (!_.isEmpty(child.value)) {
+      if (isNonEmptyString(child.value)) {
         return child.value
       } else if (child.children && child.children.length > 0) {
         return extractText(child.children)


### PR DESCRIPTION
I really like this package. But I found something to improve in this package.

`lodash` transitive dependency sometimes become a little bit burden for us (end-user app devs) because lodash sometimes reported as vulnerable.

That kind of situation is becoming more often thanks to active diagnostics using AI or due to frequently happening supply-chain attacks.

So I believe that removing lodash from deps will keep this package resilient against supply-chain attacks and (close to) maintenance free.

Inspired by: https://e18e.dev/learn/cleanup.html